### PR TITLE
Don't pass null to memcpy and simplify debug assert

### DIFF
--- a/common/internal/byte_string.cc
+++ b/common/internal/byte_string.cc
@@ -946,7 +946,10 @@ void ByteString::SetSmall(google::protobuf::Arena* absl_nullable arena,
   rep_.header.kind = ByteStringKind::kSmall;
   rep_.small.size = string.size();
   rep_.small.arena = arena;
-  std::memcpy(rep_.small.data, string.data(), rep_.small.size);
+  // Some libc declarations require non-null pointers even for zero-byte copies.
+  if (!string.empty()) {
+    std::memcpy(rep_.small.data, string.data(), rep_.small.size);
+  }
 }
 
 void ByteString::SetSmall(google::protobuf::Arena* absl_nullable arena,

--- a/common/internal/byte_string.cc
+++ b/common/internal/byte_string.cc
@@ -946,7 +946,6 @@ void ByteString::SetSmall(google::protobuf::Arena* absl_nullable arena,
   rep_.header.kind = ByteStringKind::kSmall;
   rep_.small.size = string.size();
   rep_.small.arena = arena;
-  // Some libc declarations require non-null pointers even for zero-byte copies.
   if (!string.empty()) {
     std::memcpy(rep_.small.data, string.data(), rep_.small.size);
   }

--- a/common/internal/byte_string_test.cc
+++ b/common/internal/byte_string_test.cc
@@ -124,6 +124,12 @@ TEST_P(ByteStringTest, Default) {
   EXPECT_EQ(GetKind(byte_string), ByteStringKind::kSmall);
 }
 
+TEST_P(ByteStringTest, ConstructNullDataStringView) {
+  ByteString byte_string(GetAllocator(), absl::string_view());
+  EXPECT_THAT(byte_string, IsEmpty());
+  EXPECT_EQ(byte_string.GetArena(), GetAllocator().arena());
+}
+
 TEST_P(ByteStringTest, ConstructSmallCString) {
   ByteString byte_string = ByteString(GetAllocator(), GetSmallString().c_str());
   EXPECT_THAT(byte_string, SizeIs(GetSmallStringView().size()));

--- a/common/value.h
+++ b/common/value.h
@@ -2802,7 +2802,7 @@ absl::StatusOr<std::pair<Value, int>> StructValueMixin<Base>::Qualify(
     const google::protobuf::DescriptorPool* absl_nonnull descriptor_pool,
     google::protobuf::MessageFactory* absl_nonnull message_factory,
     google::protobuf::Arena* absl_nonnull arena) const {
-  ABSL_DCHECK_GT(qualifiers.size(), 0);
+  ABSL_DCHECK(!qualifiers.empty());
   ABSL_DCHECK(descriptor_pool != nullptr);
   ABSL_DCHECK(message_factory != nullptr);
   ABSL_DCHECK(arena != nullptr);


### PR DESCRIPTION
Envoy has had some very long-standing patches for cel-cpp that get triggered by its stricter build that enables address sanitization and `-Wextra`. AFAICT these small issues are all that prevents Envoy from updating to a latest upstream cel-cpp dependency (the other parts of the patch are already present here).

https://github.com/envoyproxy/bazel-registry/blob/b6e15c00b1c0493cd194b1b248c562bd8bc46648/modules/cel-cpp/0.14.0.envoy/patches/cel-cpp.patch

A `memcpy` always needs to have non-null pointers, at least until C20 becomes mainstream, which is typically accomplished by a length check. While downstream effects are unlikely, it seems theoretically possible for SetSmall to be inlined before a nullptr check that gets erased, so a highly theoretical bug that triggers sanitizers.

Envoy being able to update would unblock work to support Windows @yanavlasov is working on. I suspect being able to use upstream cel-cpp would make @phlax happy too